### PR TITLE
Fix typo in magic link + OTP login SMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This is valid for ${time}.
 
 ### Magic link + OTP login
 ```
-${appame} - Login to your account
+${appname} - Login to your account
 
 Your OTP to login: ${otp}
 


### PR DESCRIPTION
Fix typo in magic link + OTP login SMS

`appname` has been misspelt as `appame`